### PR TITLE
Update natural attack tag so it recognises SPROP

### DIFF
--- a/prettylst/prettylst.pl
+++ b/prettylst/prettylst.pl
@@ -2964,6 +2964,7 @@ my %master_order = (
 		'FAVCLASS',
 		'XTRASKILLPTSPERLVL',
 		'STARTFEATS',
+		'FACT:*',
 		'SIZE',
 		'MOVE',
 		'MOVECLONE',
@@ -3828,10 +3829,11 @@ my %column_with_no_tag = (
 
 );
 
-
+# Added FACT:Basesize despite the fact that this appears to be unused arw - 20180830
 my %token_FACT_tag = map { $_ => 1 } (
 	'FACT:Abb',
 	'FACT:AppliedName',
+	'FACT:Basesize',
 	'FACT:ClassType',
 	'FACT:SpellType',
 	'FACT:Symbol',
@@ -4706,9 +4708,10 @@ my %tagheader = (
 
 	'RACE' => {
 		'000RaceName'		=> '# Race Name',
-		'FAVCLASS'			=> 'Favored Class',
-		'SKILLMULT'			=> 'Skill Multiplier',
-		'MONCSKILL'			=> 'Racial HD Class Skills',
+		'FACT'			=> 'Base size',
+		'FAVCLASS'		=> 'Favored Class',
+		'SKILLMULT'		=> 'Skill Multiplier',
+		'MONCSKILL'		=> 'Racial HD Class Skills',
 		'MONCCSKILL'		=> 'Racial HD Cross-class Skills',
 		'MONSTERCLASS'		=> 'Monster Class Name and Starting Level',
 	},
@@ -5833,7 +5836,7 @@ if ( $cl_options{xcheck} ) {
 		for my $linetype ( sort keys %missing_headers ) {
 		if ($firsttime) {
 			print STDERR "\n================================================================\n";
-			print STDERR "List of TAGs whitout defined header in \%tagheader\n";
+			print STDERR "List of TAGs without defined header in \%tagheader\n";
 			print STDERR "----------------------------------------------------------------\n";
 		}
 

--- a/prettylst/prettylst.pl
+++ b/prettylst/prettylst.pl
@@ -9181,8 +9181,19 @@ BEGIN {
 			for my $entry ( split '\|', $tag_value ) {
 				my @parameters = split ',', $entry;
 
-				# Must have 4 parameters
-				if ( scalar @parameters == 4 ) {
+				my $NumberOfParams = scalar @parameters;
+
+				# must have 4 or 5 parameters
+				if ($NumberOfParams == 5 or $NumberOfParams == 4) { 
+				
+					# If Parameter 5 exists, it must be an SPROP
+					if (defined $parameters[4]) {
+						$logging->ewarn( NOTICE,
+							qq{5th parameter should be an SPROP in "NATURALATTACKS:$entry"},
+							$file_for_error,
+							$line_for_error
+						) unless $parameters[4] =~ /^SPROP=/;
+					}
 
 					# Parameter 3 is a number
 					$logging->ewarn( NOTICE,


### PR DESCRIPTION
The natural attacks tag takes an optional SPROP tag, modify prettylst so it recognises that there may be four or five sections, and make sure that if the fifth section is there that it is an SPROP.